### PR TITLE
Remove empty <img> tag in footer

### DIFF
--- a/src/app/components/justfixFooter/footer.html
+++ b/src/app/components/justfixFooter/footer.html
@@ -1,10 +1,6 @@
 <div class="footer-wrap white">
   <footer class="footer-fixed-bottom">
     <div class="container main">
-    	<div class="">
-    		<img src="" />
-    	</div>
-
     	<div class="pull-left logo">
     		<a ui-sref="home">
 					<img src="/img/brand/logo_blue.png" />


### PR DESCRIPTION
Hey folks!

I was just looking at your site and noticed this in the footer:

<img width="297" alt="screen shot 2017-12-30 at 9 04 20 pm" src="https://user-images.githubusercontent.com/1312199/34458566-0ae571e0-eda5-11e7-84e8-a6463b3623db.png">

Since you're open source, I figured I'd just fix it 😄

Thanks so much for all of the important work you do!