### PR TITLE
Add funders title and logos to partners page

### DIFF
--- a/src/app/modules/about/partners/partners.html
+++ b/src/app/modules/about/partners/partners.html
@@ -31,6 +31,27 @@
       zoom="11">
     </carto-map>
   </section>
+
+  <header class="container">
+    <h1 class="center">{{$contentfulEntry.fields.fundersTitle}}</h1>
+  </header>
+
+  <div class="clearfix"></div>
+  <section class="center no-margin">
+    <div class="logos container">
+      <span
+        class="logo partners"
+        ng-repeat="funder in $contentfulEntry.fields.funders track by $index"
+        >
+        <a ng-href="{{funder.fields.link}}" target="_blank">
+          <div class="background-image"
+            ng-style="{'background-image': 'url(' + funder.fields.logo.fields.file.url + ')'}">
+          </div>
+        </a>
+      </span>
+    </div>
+  </section>
+
   <section class="alt center no-margin-top">
   	<div class="container" ng-bind-html="$contentfulEntry.fields.collaborationTextBlock | markdown">
 		</div>


### PR DESCRIPTION
As there are 8 logos instead of a greater number like with the partners, don't offset the 1st one so that they can live only on two rows.

Screenshots:

<img width="1203" alt="screenshot 2018-04-19 16 41 19" src="https://user-images.githubusercontent.com/1305667/39017414-3943feec-43f1-11e8-9def-2b815e526648.png">
<img width="372" alt="screenshot 2018-04-19 16 42 14" src="https://user-images.githubusercontent.com/1305667/39017415-3aae4292-43f1-11e8-8993-a4abe8af7865.png">
