### PR TITLE
Replace video unit videos

### DIFF
--- a/src/app/components/footerVideo/footerVideo.html
+++ b/src/app/components/footerVideo/footerVideo.html
@@ -3,7 +3,7 @@
     <div class="row align_items_end-sm">
       <div class="col-sm-6 col-sm-offset-1">
         <div class="video_wrapper_16_9">
-          <video class="video_wrapper_16_9-video" ng-src="{{$contentfulEntry.fields.videoUnit.fields.video.fields.file.url | trustUrl}}" autoplay muted playsinline controls></video>
+          <iframe class="video_wrapper_16_9-video" src="https://www.youtube.com/embed/4oF5SN1b6oY?rel=0&amp&autoplay=1&mute=1;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
         </div>
       </div>
       <div class="col-sm-5">

--- a/src/app/modules/main/main.html
+++ b/src/app/modules/main/main.html
@@ -68,7 +68,7 @@
       <div class="row align_items_end-sm">
         <div class="col-sm-8">
           <div class="video_wrapper_16_9">
-            <video class="video_wrapper_16_9-video" ng-src="{{$contentfulEntry.fields.videoUnit.fields.video.fields.file.url | trustUrl}}" autoplay muted playsinline controls></video>
+            <iframe class="video_wrapper_16_9-video" src="https://www.youtube.com/embed/QsRq3OWNkgY?rel=0&amp&autoplay=1&mute=1;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
           </div>
         </div>
         <div class="col-sm-4">

--- a/src/app/modules/mission/mission.html
+++ b/src/app/modules/mission/mission.html
@@ -7,7 +7,7 @@
       <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-lg-8 col-lg-offset-2">
           <div class="video_wrapper_16_9">
-            <video class="video_wrapper_16_9-video" ng-src="{{$contentfulEntry.fields.videoUnit.fields.video.fields.file.url | trustUrl}}" autoplay muted playsinline controls></video>
+            <iframe class="video_wrapper_16_9-video" src="https://www.youtube.com/embed/QsRq3OWNkgY?rel=0&amp&autoplay=1&mute=1;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Replace contentful videos with manual Youtube embeds.

<img width="1378" alt="screenshot 2018-04-24 18 00 26" src="https://user-images.githubusercontent.com/1305667/39216453-ba3aabf8-47e9-11e8-9203-7902af333643.png">
<img width="1414" alt="screenshot 2018-04-24 18 03 55" src="https://user-images.githubusercontent.com/1305667/39216498-e6400658-47e9-11e8-8841-1bf93c49e140.png">
<img width="1354" alt="screenshot 2018-04-24 18 00 11" src="https://user-images.githubusercontent.com/1305667/39216459-bd1d9056-47e9-11e8-8762-e41e62706ffe.png">
